### PR TITLE
Change setup.py so it doesn't fail if the README.rst file is not present

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,9 @@ Usage
 
     from countminsketch import CountMinSketch
     sketch = CountMinSketch(1000, 10)  # table size=1000, hash functions=10
-    sketch.update("oh yeah")
-    sketch.update(tuple())
-    sketch.update(1, value=123)
+    sketch.add("oh yeah")
+    sketch.add(tuple())
+    sketch.add(1, value=123)
     print sketch["oh yeah"]       # prints 1
     print sketch[tuple()]         # prints 1
     print sketch[1]               # prints 123

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,11 @@ except ImportError:
 
 
 base_path = os.path.dirname(os.path.abspath(__file__))
-long_description = open(os.path.join(base_path, 'README.rst')).read()
+
+long_description = ''
+readme_path = os.path.join(base_path, 'README.rst')
+if os.path.isfile(readme_path):
+    long_description = open(readme_path).read()
 
 setup(
     name="countminsketch",


### PR DESCRIPTION
Fixes for a couple of issues:
* Trying to install from Pypi, I was seeing a crash in setup.py, trying to open the README.rst file which was not present in the .tar.gz file.
* The README.rst example calls update(), but the actual function is called add().

I am hoping to use your library for an example in a book I am working on. If these changes look okay, it would be great if you could push a new version to Pypi.